### PR TITLE
Adding Unit Tests to project TurnState

### DIFF
--- a/App.UnitTests/App.UnitTests.csproj
+++ b/App.UnitTests/App.UnitTests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C6FF7814-11C5-4856-902B-9717E9C3A743}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>App.UnitTests</RootNamespace>
+    <AssemblyName>App.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>C:\Program Files\Unity\Editor\Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BattleSystem\Entity\TurnStateTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\App\App.csproj">
+      <Project>{3295384f-5222-4aaa-92b8-b86d81dde225}</Project>
+      <Name>App</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/App.UnitTests/BattleSystem/Entity/TurnStateTests.cs
+++ b/App.UnitTests/BattleSystem/Entity/TurnStateTests.cs
@@ -1,0 +1,115 @@
+﻿using App.BattleSystem.Action;
+using App.BattleSystem.Entity;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace App.UnitTests.BattleSystem.Entity
+{
+    [TestFixture]
+    public class TurnStateTests
+    {
+        private const float DEFAULT_TIME = 5f;
+        private TurnState subject;
+
+        [SetUp]
+        public void Init()
+        {
+            subject = new TurnState();
+        }
+
+        private IBattleAction createAction(float prepare = DEFAULT_TIME, float execute = DEFAULT_TIME, float recover = DEFAULT_TIME)
+        {
+            var sub = Substitute.For<IBattleAction>();
+            sub.TimePrepare.Returns(prepare);
+            sub.TimeAction.Returns(execute);
+            sub.TimeRecover.Returns(recover);
+            return sub;
+        }
+
+        [Test]
+        public void TestSetAction_InitialValueIsPrepare()
+        {
+            subject.SetAction(createAction());
+            Assert.That(subject.Phase, Is.EqualTo(TurnState.PhaseState.PREPARE));
+        }
+
+        [Test]
+        public void TestSetAction_TurnClockInitialValues()
+        {
+            subject.SetAction(createAction());
+            Assert.That(subject.TurnClock, Is.EqualTo(0));
+            Assert.That(subject.TurnComplete, Is.EqualTo(DEFAULT_TIME));
+            Assert.That(subject.TurnPercent, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestTransition_ToExecute_FiresEvent()
+        {
+            var callback = Substitute.For<TurnState.OnStartActionExecution>();
+            subject.OnStartActionExecutionDelegate += callback;
+            subject.SetAction(createAction());
+            subject.IncrementGameClock(DEFAULT_TIME);
+            callback.Received().Invoke();
+            Assert.That(subject.Phase, Is.EqualTo(TurnState.PhaseState.EXECUTE));
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(5)]
+        public void TestTransition_ToExecute_PhaseUpdated(float prepareTime)
+        {
+            subject.SetAction(createAction(prepare: prepareTime));
+            subject.IncrementGameClock(prepareTime);
+            Assert.That(subject.Phase, Is.EqualTo(TurnState.PhaseState.EXECUTE));
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(5)]
+        public void TestTransition_ToRecover_PhaseUpdated(float executeTime)
+        {            
+            subject.SetAction(createAction(execute: executeTime));
+            subject.IncrementGameClock(DEFAULT_TIME);
+            subject.IncrementGameClock(executeTime);
+            Assert.That(subject.Phase, Is.EqualTo(TurnState.PhaseState.RECOVER));
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(5)]
+        public void TestTransition_ToInputRequired_PhaseUpdated(float recoveryTime)
+        {
+            subject.SetAction(createAction(recover: recoveryTime));
+            subject.IncrementGameClock(DEFAULT_TIME);
+            subject.IncrementGameClock(DEFAULT_TIME);
+            subject.IncrementGameClock(recoveryTime);
+            Assert.That(subject.Phase, Is.EqualTo(TurnState.PhaseState.REQUIRES_INPUT));
+        }
+
+        [TestCase(1, 0)]
+        [TestCase(3, 0)]
+        [TestCase(2, 1)]
+        [TestCase(1.5f, 1)]
+        [TestCase(3, 2)]
+        [TestCase(4.5f, 2)]
+        public void TestTransition_DeltaOverAction_TurnClockZero(float timePassedOneTick, float prepareTime)
+        {
+            subject.SetAction(createAction(prepare: prepareTime));
+            subject.IncrementGameClock(timePassedOneTick);
+            Assert.That(subject.TurnClock, Is.EqualTo(0));
+        }
+
+
+        [TestCase(0.5f, 1)]
+        [TestCase(0.25f, 1)]
+        [TestCase(1f, 2)]        
+        [TestCase(1.5f, 2)]
+        [TestCase(0.05f, 4)]        
+        public void TestTransition_DeltaBeforeTurn(float timePassedOneTick, float prepareTime)
+        {
+            subject.SetAction(createAction(prepare: prepareTime));
+            subject.IncrementGameClock(timePassedOneTick);
+            Assert.That(subject.TurnClock, Is.EqualTo(timePassedOneTick));
+        }
+    }
+}

--- a/App.UnitTests/Properties/AssemblyInfo.cs
+++ b/App.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("App.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("App.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("c6ff7814-11c5-4856-902b-9717e9c3a743")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/App.UnitTests/packages.config
+++ b/App.UnitTests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.2.0" targetFramework="net471" />
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net471" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net471" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net471" />
+  <package id="NUnit" version="3.10.1" targetFramework="net471" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net471" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net471" />
+</packages>

--- a/App/App.csproj
+++ b/App/App.csproj
@@ -220,7 +220,6 @@
     <Compile Include="Core\Characters\PCSkillSetSO.cs" />
     <Compile Include="Core\Characters\TestPartyComponent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TurnManager\DecisionState.cs" />
     <Compile Include="Util\SceneLoader.cs" />
     <Compile Include="Util\Size.cs" />
     <Compile Include="Core\Tags.cs" />

--- a/App/BattleSystem/Entity/BattleEntity.cs
+++ b/App/BattleSystem/Entity/BattleEntity.cs
@@ -57,6 +57,7 @@ namespace App.BattleSystem.Entity
             statusEffectManager = new StatusEffectClient(this);
             combatNodeFactory = new CombatNodeFactory(this);
             TurnState = new TurnState();
+            TurnState.OnStartActionExecutionDelegate += OnExecuteStart;
             this.Character = character;
             this.MaxHP = character.MaxHP;
             this.CurrentHP = character.curHP;
@@ -64,6 +65,7 @@ namespace App.BattleSystem.Entity
 
         public void InitializeBattlePhase()
         {
+            // this value is temp until we assign an initiative per character
             TurnState.SetAction(new BattleActionInitiative(Random.Range(1, 5)));
         }
 

--- a/Ludum/Ludum.sln
+++ b/Ludum/Ludum.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
+VisualStudioVersion = 15.0.28010.2026
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Davfalcon", "..\rpglibrary\Davfalcon\Davfalcon.csproj", "{1FCB4578-21B8-4DB5-B560-C87BEEB7FD2E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Davfalcon.Unity", "..\rpglibrary\Unity\Davfalcon.Unity\Davfalcon.Unity.csproj", "{37146187-BC62-44E6-BCE1-EBC64C6C9224}"
@@ -12,6 +14,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Davfalcon.Revelator.UnitTests", "..\rpglibrary\Davfalcon.Revelator.UnitTests\Davfalcon.Revelator.UnitTests.csproj", "{B6F86762-E634-4425-9D8B-1C0873B7E12B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "..\App\App.csproj", "{3295384F-5222-4AAA-92B8-B86D81DDE225}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App.UnitTests", "App.UnitTests\App.UnitTests.csproj", "{C6FF7814-11C5-4856-902B-9717E9C3A743}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -43,8 +47,15 @@ Global
 		{3295384F-5222-4AAA-92B8-B86D81DDE225}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3295384F-5222-4AAA-92B8-B86D81DDE225}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3295384F-5222-4AAA-92B8-B86D81DDE225}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6FF7814-11C5-4856-902B-9717E9C3A743}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6FF7814-11C5-4856-902B-9717E9C3A743}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6FF7814-11C5-4856-902B-9717E9C3A743}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6FF7814-11C5-4856-902B-9717E9C3A743}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D541A0D8-2DA7-436D-AA65-7012D24B6B15}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
* Creates new App.UnitTests project in root directory
* updated references to include unity into test project (otherwise certain Mathf functions from unity wont work in unit test environment.  This is probably because we are not allowing that DLL to be copied.)
* Added unit test around TurnState
* Fixed revealed bugs from tests.