### PR TITLE
AI Tests, class renaming, visibility adjusted for tests

### DIFF
--- a/Redninja.UnitTests/AI/AIRuleBaseTests.cs
+++ b/Redninja.UnitTests/AI/AIRuleBaseTests.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Davfalcon.Revelator;
+using NSubstitute;
+using NUnit.Framework;
+using Redninja.AI;
+using Redninja.Targeting;
+
+namespace Redninja.UnitTests.AI
+{
+	[TestFixture]
+	public abstract class AIRuleBaseTests<T> where T : AIRuleBase.BuilderBase<T>
+	{
+		private IBattleEntityManager mBem;		
+		private IBattleEntity mSource;
+		private int sourceTeam;
+		private int enemyTeam;
+		private List<IBattleEntity> allEntities;
+		
+		private TestableRuleBase.Builder subjectBuilder;
+
+		protected abstract AIRuleBase.BuilderBase<T> Builder { get; }
+
+		[SetUp]
+		public void Setup()
+		{
+			enemyTeam = 1;
+			sourceTeam = 2;
+
+			mBem = Substitute.For<IBattleEntityManager>();
+			mSource = Substitute.For<IBattleEntity>();
+			mSource.Team.Returns(sourceTeam);
+
+			allEntities = new List<IBattleEntity>() { mSource };
+			mBem.AllEntities.Returns(allEntities);
+
+			subjectBuilder = new TestableRuleBase.Builder();
+			subjectBuilder.SetWeight(1);
+			subjectBuilder.SetName("test");
+		}
+
+		private IBattleEntity AddEntity(int teamId)
+		{
+			var mEntity = Substitute.For<IBattleEntity>();
+			mEntity.Team.Returns(teamId);
+			allEntities.Add(mEntity);
+			return mEntity;
+		}
+
+		private IAITargetCondition AddMockCondition(TargetTeam target, bool isValid, IBattleEntity entityArg = null)
+		{
+			IAITargetCondition mockCondition = Substitute.For<IAITargetCondition>();
+			mockCondition.IsValid(entityArg?? Arg.Any<IBattleEntity>()).Returns(isValid);
+			subjectBuilder.AddTriggerCondition(target, mockCondition);
+			return mockCondition;
+		}
+		
+		[Test]
+		public void IsValidCondition_ReturnsTrue(
+			[Values] TargetTeam target, 
+			[Range(1, 4)] int numberOfTrueConditions)
+		{			
+		
+			for(int i=0; i < numberOfTrueConditions; i++)
+			{
+				AddMockCondition(target, true);				
+			}
+
+			AddEntity(sourceTeam);
+			AddEntity(enemyTeam);
+
+			var subject = subjectBuilder.Build();
+			bool result = subject.IsValidTriggerConditions(mSource, mBem);
+
+			Assert.That(result, Is.True);
+		}
+
+		[Test]
+		public void IsValidCondition_ReturnsFalse(
+			[Values] TargetTeam target,
+			[Range(0, 2)] int numberOfTrueConditions)
+		{
+			for (int i = 0; i < numberOfTrueConditions; i++)
+			{
+				AddMockCondition(target, true);
+			}
+
+			AddMockCondition(target, false);	// add one to fail the test of AND statements
+
+			AddEntity(sourceTeam);
+			AddEntity(enemyTeam);
+
+			var subject = subjectBuilder.Build();
+			bool result = subject.IsValidTriggerConditions(mSource, mBem);
+
+			Assert.That(result, Is.False);
+		}
+
+		[Test]
+		public void IsValidCondition_ChecksTarget([Values] TargetTeam target)
+		{
+			IEnumerable<IBattleEntity> entities;
+			switch(target)
+			{
+				case TargetTeam.Ally:
+					entities = allEntities.Where(x => x.Team == mSource.Team);
+					break;
+				case TargetTeam.Self:
+					entities = allEntities.Where(x => x == mSource);
+					break;
+				case TargetTeam.Enemy:
+					entities = allEntities.Where(x => x.Team != mSource.Team);
+					break;
+				case TargetTeam.Any:
+				default:
+					entities = allEntities;
+					break;
+			}
+
+			AddEntity(sourceTeam);
+			AddEntity(enemyTeam);
+
+			var mCondition = AddMockCondition(target, true);
+
+			var subject = subjectBuilder.Build();
+			subject.IsValidTriggerConditions(mSource, mBem);
+
+			mCondition.Received().IsValid(Arg.Is<IBattleEntity>(x => entities.Contains(x)));
+		}
+
+		[TestCase(0)]
+		[TestCase(-1)]
+		[TestCase(-20)]
+		public void BuilderInvalidWeight_ThrowsException(int weight)
+		{
+			subjectBuilder.SetWeight(weight);
+
+			Assert.Throws<InvalidOperationException>(() => subjectBuilder.Build());
+		}
+
+		[TestCase("first")]
+		[TestCase("second")]
+		[TestCase("the third")]
+		public void BuilderName_IsBuilt(string name)
+		{
+			subjectBuilder.SetName(name);
+
+			var subject = subjectBuilder.Build();
+			Assert.That(subject.RuleName, Is.EqualTo(name));
+		}
+
+		[TestCase(0)]
+		[TestCase(10)]
+		[TestCase(30)]
+		public void BuilderRefresh_IsBuilt(int refresh)
+		{
+			subjectBuilder.SetRefreshTime(refresh);
+
+			var subject = subjectBuilder.Build();
+			Assert.That(subject.RefreshTime, Is.EqualTo(refresh));
+		}
+
+		/// <summary>
+		/// Make this abstract class to be testable.
+		/// </summary>
+		internal class TestableRuleBase : AIRuleBase
+		{			
+
+			public override IBattleAction GenerateAction(IBattleEntity source, IBattleEntityManager bem)
+			{
+				return null; // ignored in tests
+			}
+
+			internal class Builder : AIRuleBase.BuilderBase<Builder>, IBuilder<TestableRuleBase>
+			{
+				private TestableRuleBase rule;
+				internal Builder() => Reset();
+
+				public Builder Reset()
+				{
+					rule = new TestableRuleBase();
+					ResetBase(rule);
+					return this;
+				}
+
+				public TestableRuleBase Build()
+				{
+					BuildBase();
+					return rule;
+				}
+			}
+		}
+	}
+}

--- a/Redninja.UnitTests/AI/AIRuleBaseTests.cs
+++ b/Redninja.UnitTests/AI/AIRuleBaseTests.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Davfalcon.Revelator;
-using NSubstitute;
+﻿using NSubstitute;
 using NUnit.Framework;
 using Redninja.AI;
 using Redninja.Decisions;
 using Redninja.Targeting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Redninja.UnitTests.AI
 {

--- a/Redninja.UnitTests/AI/AIRuleSetTests.cs
+++ b/Redninja.UnitTests/AI/AIRuleSetTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NSubstitute;
+﻿using NSubstitute;
 using NUnit.Framework;
 using Redninja.AI;
 using Redninja.Decisions;

--- a/Redninja.UnitTests/AI/AIRuleSetTests.cs
+++ b/Redninja.UnitTests/AI/AIRuleSetTests.cs
@@ -6,21 +6,21 @@ using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
 using Redninja.AI;
+using Redninja.Decisions;
 
 namespace Redninja.UnitTests.AI
 {
 	[TestFixture]
 	public class AIRuleSetTests
-	{
-		private IBattleEntityManager mBem;		
+	{		
+		private IDecisionHelper mDecisionHelper;
 		private IBattleEntity mSource;
 		private IAIHistoryState mHistory;
 		private AIRuleSet.Builder builder;
 
 		[SetUp]
 		public void Setup()
-		{
-			mBem = Substitute.For<IBattleEntityManager>();
+		{			
 			mSource = Substitute.For<IBattleEntity>();
 			mHistory = Substitute.For<IAIHistoryState>();
 			builder = new AIRuleSet.Builder();
@@ -31,9 +31,9 @@ namespace Redninja.UnitTests.AI
 			IAIRule rule = Substitute.For<IAIRule>();
 
 			rule.Weight.Returns(weight);
-			rule.IsValidTriggerConditions(Arg.Any<IBattleEntity>(), Arg.Any<IBattleEntityManager>())
+			rule.IsValidTriggerConditions(Arg.Any<IBattleEntity>(), Arg.Any<IDecisionHelper>())
 				.Returns(isValidTrigger);
-			rule.GenerateAction(Arg.Any<IBattleEntity>(), Arg.Any<IBattleEntityManager>())
+			rule.GenerateAction(Arg.Any<IBattleEntity>(), Arg.Any<IDecisionHelper>())
 				.Returns(willBuildAction ? Substitute.For<IBattleAction>() : null);
 
 			return rule;
@@ -53,7 +53,7 @@ namespace Redninja.UnitTests.AI
 			mHistory.IsRuleReady(Arg.Any<IAIRule>()).Returns(true);
 
 			var subject = builder.Build();
-			var result = subject.ResolveAction(mSource, mBem, mHistory);
+			var result = subject.ResolveAction(mSource, mDecisionHelper, mHistory);
 
 			Assert.That(result, Is.Not.Null);
 		}
@@ -73,7 +73,7 @@ namespace Redninja.UnitTests.AI
 
 			var subject = builder.Build();
 
-			var result = subject.ResolveAction(mSource, mBem, mHistory);
+			var result = subject.ResolveAction(mSource, mDecisionHelper, mHistory);
 
 			Assert.That(result, Is.Null);
 		}
@@ -87,7 +87,7 @@ namespace Redninja.UnitTests.AI
 
 			var subject = builder.Build();
 
-			var result = subject.ResolveAction(mSource, mBem, mHistory);
+			var result = subject.ResolveAction(mSource, mDecisionHelper, mHistory);
 
 			mHistory.Received().IsRuleReady(mRule);
 			Assert.That(result, Is.Null);

--- a/Redninja.UnitTests/AI/AIRuleSetTests.cs
+++ b/Redninja.UnitTests/AI/AIRuleSetTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+using Redninja.AI;
+
+namespace Redninja.UnitTests.AI
+{
+	[TestFixture]
+	public class AIRuleSetTests
+	{
+		private IBattleEntityManager mBem;		
+		private IBattleEntity mSource;
+		private IAIHistoryState mHistory;
+		private AIRuleSet.Builder builder;
+
+		[SetUp]
+		public void Setup()
+		{
+			mBem = Substitute.For<IBattleEntityManager>();
+			mSource = Substitute.For<IBattleEntity>();
+			mHistory = Substitute.For<IAIHistoryState>();
+			builder = new AIRuleSet.Builder();
+		}
+		
+		private IAIRule CreateMockRule(int weight, bool isValidTrigger, bool willBuildAction)
+		{
+			IAIRule rule = Substitute.For<IAIRule>();
+
+			rule.Weight.Returns(weight);
+			rule.IsValidTriggerConditions(Arg.Any<IBattleEntity>(), Arg.Any<IBattleEntityManager>())
+				.Returns(isValidTrigger);
+			rule.GenerateAction(Arg.Any<IBattleEntity>(), Arg.Any<IBattleEntityManager>())
+				.Returns(willBuildAction ? Substitute.For<IBattleAction>() : null);
+
+			return rule;
+		}
+
+		[TestCase(true, true)]
+		[TestCase(true, false, false, false, true, true)]
+		[TestCase(false, true, false, false, true, false, true, true)]
+		[TestCase(true, true, true, false, false, false, true, true)]
+		public void ResolveAction_FindsAction(params bool[] validBuildPairs)
+		{
+			for (int i= 0; i < validBuildPairs.Length; i+=2) 
+			{
+				builder.AddRule(CreateMockRule(1, validBuildPairs[i], validBuildPairs[i+1]));
+			}
+
+			mHistory.IsRuleReady(Arg.Any<IAIRule>()).Returns(true);
+
+			var subject = builder.Build();
+			var result = subject.ResolveAction(mSource, mBem, mHistory);
+
+			Assert.That(result, Is.Not.Null);
+		}
+
+		[TestCase(false, true)]
+		[TestCase(true, false, false, false, true, false)]
+		[TestCase(false, true, false, false, true, false, false, false)]
+		[TestCase(true, false, true, false, false, false)]
+		public void ResolveAction_FailsReturnsNoAction(params bool[] validBuildPairs)
+		{			
+			for (int i = 0; i < validBuildPairs.Length; i += 2)
+			{
+				builder.AddRule(CreateMockRule(1, validBuildPairs[i], validBuildPairs[i + 1]));
+			}
+
+			mHistory.IsRuleReady(Arg.Any<IAIRule>()).Returns(true);
+
+			var subject = builder.Build();
+
+			var result = subject.ResolveAction(mSource, mBem, mHistory);
+
+			Assert.That(result, Is.Null);
+		}
+
+		[Test]
+		public void ResolveAction_IgnoredInvalidRuleFromHistory()
+		{
+			IAIRule mRule = CreateMockRule(1, true, true);
+			mHistory.IsRuleReady(mRule).Returns(false);
+			builder.AddRule(mRule);
+
+			var subject = builder.Build();
+
+			var result = subject.ResolveAction(mSource, mBem, mHistory);
+
+			mHistory.Received().IsRuleReady(mRule);
+			Assert.That(result, Is.Null);
+		}
+	}
+}

--- a/Redninja.UnitTests/AI/AISkillRuleTests.cs
+++ b/Redninja.UnitTests/AI/AISkillRuleTests.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Davfalcon.Revelator;
+using NSubstitute;
+using NUnit.Framework;
+using Redninja.AI;
+using Redninja.Targeting;
+
+namespace Redninja.UnitTests.AI
+{
+	[TestFixture]
+	public class AISkillRuleTests
+	{
+		private IBattleEntityManager mBem;		
+		private IBattleEntity mSource;
+		private int sourceTeam;
+		private int enemyTeam;
+		private List<IBattleEntity> allEntities;
+		
+		private AISkillRule.Builder subjectBuilder;
+
+		[SetUp]
+		public void Setup()
+		{
+			enemyTeam = 1;
+			sourceTeam = 2;
+
+			mBem = Substitute.For<IBattleEntityManager>();
+			mSource = Substitute.For<IBattleEntity>();
+			mSource.Team.Returns(sourceTeam);
+
+			allEntities = new List<IBattleEntity>() { mSource };
+			mBem.AllEntities.Returns(allEntities);
+
+			subjectBuilder = new AISkillRule.Builder();
+			subjectBuilder.SetWeight(1);
+			subjectBuilder.SetName("test");
+		}
+
+		private IBattleEntity AddEntity(int teamId)
+		{
+			var mEntity = Substitute.For<IBattleEntity>();
+			mEntity.Team.Returns(teamId);
+			allEntities.Add(mEntity);
+			return mEntity;
+		}
+
+		private IAITargetCondition AddMockCondition(TargetTeam target, bool isValid, IBattleEntity entityArg = null)
+		{
+			IAITargetCondition mockCondition = Substitute.For<IAITargetCondition>();
+			mockCondition.IsValid(entityArg?? Arg.Any<IBattleEntity>()).Returns(isValid);
+			subjectBuilder.AddTriggerCondition(target, mockCondition);
+			return mockCondition;
+		}
+		
+		[Test]
+		public void IsValidCondition_ReturnsTrue(
+			[Values] TargetTeam target, 
+			[Range(1, 4)] int numberOfTrueConditions)
+		{			
+		
+			for(int i=0; i < numberOfTrueConditions; i++)
+			{
+				AddMockCondition(target, true);				
+			}
+
+			AddEntity(sourceTeam);
+			AddEntity(enemyTeam);
+
+			var subject = subjectBuilder.Build();
+			bool result = subject.IsValidTriggerConditions(mSource, mBem);
+
+			Assert.That(result, Is.True);
+		}
+
+		[Test]
+		public void IsValidCondition_ReturnsFalse(
+			[Values] TargetTeam target,
+			[Range(0, 2)] int numberOfTrueConditions)
+		{
+			for (int i = 0; i < numberOfTrueConditions; i++)
+			{
+				AddMockCondition(target, true);
+			}
+
+			AddMockCondition(target, false);	// add one to fail the test of AND statements
+
+			AddEntity(sourceTeam);
+			AddEntity(enemyTeam);
+
+			var subject = subjectBuilder.Build();
+			bool result = subject.IsValidTriggerConditions(mSource, mBem);
+
+			Assert.That(result, Is.False);
+		}
+
+		[Test]
+		public void IsValidCondition_ChecksTarget([Values] TargetTeam target)
+		{
+			IEnumerable<IBattleEntity> entities;
+			switch(target)
+			{
+				case TargetTeam.Ally:
+					entities = allEntities.Where(x => x.Team == mSource.Team);
+					break;
+				case TargetTeam.Self:
+					entities = allEntities.Where(x => x == mSource);
+					break;
+				case TargetTeam.Enemy:
+					entities = allEntities.Where(x => x.Team != mSource.Team);
+					break;
+				case TargetTeam.Any:
+				default:
+					entities = allEntities;
+					break;
+			}
+
+			AddEntity(sourceTeam);
+			AddEntity(enemyTeam);
+
+			var mCondition = AddMockCondition(target, true);
+
+			var subject = subjectBuilder.Build();
+			subject.IsValidTriggerConditions(mSource, mBem);
+
+			mCondition.Received().IsValid(Arg.Is<IBattleEntity>(x => entities.Contains(x)));
+		}
+
+		[TestCase(0)]
+		[TestCase(-1)]
+		[TestCase(-20)]
+		public void BuilderInvalidWeight_ThrowsException(int weight)
+		{
+			subjectBuilder.SetWeight(weight);
+
+			Assert.Throws<InvalidOperationException>(() => subjectBuilder.Build());
+		}
+
+		[TestCase("first")]
+		[TestCase("second")]
+		[TestCase("the third")]
+		public void BuilderName_IsBuilt(string name)
+		{
+			subjectBuilder.SetName(name);
+
+			var subject = subjectBuilder.Build();
+			Assert.That(subject.RuleName, Is.EqualTo(name));
+		}
+
+		[TestCase(0)]
+		[TestCase(10)]
+		[TestCase(30)]
+		public void BuilderRefresh_IsBuilt(int refresh)
+		{
+			subjectBuilder.SetRefreshTime(refresh);
+
+			var subject = subjectBuilder.Build();
+			Assert.That(subject.RefreshTime, Is.EqualTo(refresh));
+		}
+
+		/// <summary>
+		/// Make this abstract class to be testable.
+		/// </summary>
+		internal class TestableRuleBase : AIRuleBase
+		{			
+
+			public override IBattleAction GenerateAction(IBattleEntity source, IBattleEntityManager bem)
+			{
+				return null; // ignored in tests
+			}
+
+			internal class Builder : AIRuleBase.BuilderBase<Builder>, IBuilder<TestableRuleBase>
+			{
+				private TestableRuleBase rule;
+				internal Builder() => Reset();
+
+				public Builder Reset()
+				{
+					rule = new TestableRuleBase();
+					ResetBase(rule);
+					return this;
+				}
+
+				public TestableRuleBase Build()
+				{
+					BuildBase();
+					return rule;
+				}
+			}
+		}
+	}
+}

--- a/Redninja.UnitTests/AI/AISkillRuleTests.cs
+++ b/Redninja.UnitTests/AI/AISkillRuleTests.cs
@@ -1,15 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Davfalcon.Revelator;
-using NSubstitute;
+﻿using NSubstitute;
 using NUnit.Framework;
 using Redninja.AI;
 using Redninja.Decisions;
 using Redninja.Skills;
 using Redninja.Targeting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Redninja.UnitTests.AI
 {

--- a/Redninja.UnitTests/AI/WeightedPoolTests.cs
+++ b/Redninja.UnitTests/AI/WeightedPoolTests.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NSubstitute;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Redninja.AI;
 
 namespace Redninja.UnitTests.AI

--- a/Redninja.UnitTests/BattlePresenterTests.cs
+++ b/Redninja.UnitTests/BattlePresenterTests.cs
@@ -38,6 +38,7 @@ namespace Redninja.UnitTests
 			kernel.Bind<ICombatExecutor>().ToConstant(mCombatExecutor);
 			kernel.Bind<IBattleEntityManager>().ToConstant(mEntityManager);
 			kernel.Bind<IBattleView>().ToConstant(mBattleView);
+			kernel.Bind<IDecisionHelper>().ToConstant(Substitute.For<IDecisionHelper>());
 			kernel.Bind<BattlePresenter.Clock>().ToConstant(clock);
 
 			subject = kernel.Get<BattlePresenter>();

--- a/Redninja.UnitTests/Decisions/PlayerDecisionManagerTests.cs
+++ b/Redninja.UnitTests/Decisions/PlayerDecisionManagerTests.cs
@@ -33,6 +33,7 @@ namespace Redninja.Decisions.UnitTests
 			kernel = new StandardKernel();
 			kernel.Bind<IBattleEntityManager>().ToConstant(mEntityManager);
 			kernel.Bind<IBattleView>().ToConstant(mBattleView);
+			kernel.Bind<IDecisionHelper>().ToConstant(Substitute.For<IDecisionHelper>());
 
 			subject = kernel.Get<PlayerDecisionManager>();
 		}

--- a/Redninja.UnitTests/Decisions/PlayerDecisionManagerTests.cs
+++ b/Redninja.UnitTests/Decisions/PlayerDecisionManagerTests.cs
@@ -1,15 +1,9 @@
-﻿using Davfalcon.Revelator;
-using Davfalcon.Revelator.Combat;
-using Ninject;
+﻿using Ninject;
 using NSubstitute;
 using NUnit.Framework;
-using Redninja.Actions;
-using Redninja.Decisions;
-using Redninja.Entities;
 using Redninja.Skills;
 using Redninja.Targeting;
 using System;
-using System.Collections.Generic;
 
 namespace Redninja.Decisions.UnitTests
 {

--- a/Redninja.UnitTests/Redninja.UnitTests.csproj
+++ b/Redninja.UnitTests/Redninja.UnitTests.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Actions\BattleActionBaseTests.cs" />
+    <Compile Include="AI\AISkillRuleTests.cs" />
     <Compile Include="AI\AIRuleBaseTests.cs" />
     <Compile Include="AI\AIRuleSetTests.cs" />
     <Compile Include="AI\WeightedPoolTests.cs" />
@@ -83,6 +84,10 @@
     <ProjectReference Include="..\rpglibrary\Davfalcon.Revelator\Davfalcon.Revelator.csproj">
       <Project>{3f1fa461-a8b2-4b6d-8c39-050069ce2a66}</Project>
       <Name>Davfalcon.Revelator</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\rpglibrary\Davfalcon\Davfalcon.csproj">
+      <Project>{1fcb4578-21b8-4db5-b560-c87beeb7fd2e}</Project>
+      <Name>Davfalcon</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup />

--- a/Redninja.UnitTests/Redninja.UnitTests.csproj
+++ b/Redninja.UnitTests/Redninja.UnitTests.csproj
@@ -63,6 +63,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Actions\BattleActionBaseTests.cs" />
+    <Compile Include="AI\AIRuleBaseTests.cs" />
+    <Compile Include="AI\AIRuleSetTests.cs" />
     <Compile Include="AI\WeightedPoolTests.cs" />
     <Compile Include="BattlePresenterTests.cs" />
     <Compile Include="Decisions\PlayerDecisionManagerTests.cs" />

--- a/Redninja/AI/AIActionDecider.cs
+++ b/Redninja/AI/AIActionDecider.cs
@@ -5,20 +5,22 @@ namespace Redninja.AI
 	public class AIActionDecider : IActionDecider
 	{
 		private AIRuleSet ruleSet;
+		private IAIHistoryState historyState;
 
 		public bool IsPlayer => false;
 
-		public AIActionDecider(AIRuleSet ruleSet)
+		public AIActionDecider(AIRuleSet ruleSet, IAIHistoryState historyState)
 		{
 			this.ruleSet = ruleSet;
+			this.historyState = historyState;
 		}
 
 		public event Action<IBattleEntity, IBattleAction> ActionSelected;
 
-		public void ProcessNextAction(IBattleEntity entity, IBattleEntityManager entityManager)
+		public void ProcessNextAction(IBattleEntity source, IBattleEntityManager entityManager)
 		{
-			IBattleAction action = ruleSet.ResolveAction(entity, entityManager);
-			ActionSelected?.Invoke(entity, action);
+			IBattleAction action = ruleSet.ResolveAction(source, entityManager, historyState);
+			ActionSelected?.Invoke(source, action);
 		}
 	}
 }

--- a/Redninja/AI/AIActionDecider.cs
+++ b/Redninja/AI/AIActionDecider.cs
@@ -1,16 +1,19 @@
-﻿using System;
+﻿using Redninja.Decisions;
+using System;
 
 namespace Redninja.AI
 {
 	public class AIActionDecider : IActionDecider
 	{
-		private AIRuleSet ruleSet;
-		private IAIHistoryState historyState;
+		private readonly AIRuleSet ruleSet;
+		private readonly IAIHistoryState historyState;
+		private readonly IDecisionHelper decisionHelper;
 
 		public bool IsPlayer => false;
 
-		public AIActionDecider(AIRuleSet ruleSet, IAIHistoryState historyState)
+		public AIActionDecider(AIRuleSet ruleSet, IAIHistoryState historyState, IDecisionHelper decisionHelper)
 		{
+			this.decisionHelper = decisionHelper;
 			this.ruleSet = ruleSet;
 			this.historyState = historyState;
 		}
@@ -19,7 +22,7 @@ namespace Redninja.AI
 
 		public void ProcessNextAction(IBattleEntity source, IBattleEntityManager entityManager)
 		{
-			IBattleAction action = ruleSet.ResolveAction(source, entityManager, historyState);
+			IBattleAction action = ruleSet.ResolveAction(source, decisionHelper, historyState);
 			ActionSelected?.Invoke(source, action);
 		}
 	}

--- a/Redninja/AI/AICombatStatCondition.cs
+++ b/Redninja/AI/AICombatStatCondition.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/AICombatStatPriority.cs
+++ b/Redninja/AI/AICombatStatPriority.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/AIConditionFactory.cs
+++ b/Redninja/AI/AIConditionFactory.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Redninja.AI
+﻿namespace Redninja.AI
 {
 	public class AIConditionFactory
 	{

--- a/Redninja/AI/AIConstants.cs
+++ b/Redninja/AI/AIConstants.cs
@@ -5,14 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Redninja.AI
-{
-	public enum AITargetType
-	{
-		Self,
-		Enemy,
-		Ally
-	}
-
+{	
 	public enum AIPriorityType
 	{
 		None,

--- a/Redninja/AI/AIConstants.cs
+++ b/Redninja/AI/AIConstants.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Redninja.AI
-{	
+﻿namespace Redninja.AI
+{
 	public enum AIPriorityType
 	{
 		None,

--- a/Redninja/AI/AIHelper.cs
+++ b/Redninja/AI/AIHelper.cs
@@ -7,15 +7,9 @@ using System.Threading.Tasks;
 
 namespace Redninja.AI
 {
-	internal class AIHelper
+	internal static class AIHelper
 	{
-		internal delegate int ExtractValue(IBattleEntity entity);
-
-		private AIHelper()
-		{
-
-		}
-
+		internal delegate int ExtractValue(IBattleEntity entity);	
 
 		/// <summary>
 		/// Filter total entities by AITargetType.

--- a/Redninja/AI/AIHelper.cs
+++ b/Redninja/AI/AIHelper.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/AIHelper.cs
+++ b/Redninja/AI/AIHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Redninja.Targeting;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -23,16 +24,18 @@ namespace Redninja.AI
 		/// <param name="source"></param>
 		/// <param name="bem"></param>
 		/// <returns></returns>
-		internal static IEnumerable<IBattleEntity> FilterByType(AITargetType type, IBattleEntity source, IBattleEntityManager bem)
+		internal static IEnumerable<IBattleEntity> FilterByType(TargetTeam type, IBattleEntity source, IBattleEntityManager bem)
 		{
 			switch (type)
 			{
-				case AITargetType.Ally:
+				case TargetTeam.Ally:
 					return bem.AllEntities.Where(x => x.Team == source.Team);
-				case AITargetType.Enemy:
+				case TargetTeam.Enemy:
 					return bem.AllEntities.Where(x => x.Team != source.Team);
-				case AITargetType.Self:
+				case TargetTeam.Self:
 					return new List<IBattleEntity>() { source };
+				case TargetTeam.Any:
+					return bem.AllEntities;
 				default:
 					throw new InvalidProgramException("Unexpected target type, should implement!");
 			}

--- a/Redninja/AI/AIMovementRule.cs
+++ b/Redninja/AI/AIMovementRule.cs
@@ -17,7 +17,7 @@ namespace Redninja.AI
 	public class AIMovementRule : AIRuleBase
 	{
 		
-		public override IBattleAction GenerateAction(IBattleEntity source, IBattleEntityManager bem)
+		public override IBattleAction GenerateAction(IBattleEntity source, IDecisionHelper decisionHelper)
 		{
 			// psuedo code for now
 			// 1. Find available tiles you can move to (cannot be occupied or have units currently moving there)
@@ -29,7 +29,7 @@ namespace Redninja.AI
 		/// <summary>
 		/// Builder class for a rule.
 		/// </summary>
-		public class Builder : AIRuleBase.BuilderBase<Builder>, IBuilder<AIMovementRule>
+		public class Builder : AIRuleBase.BuilderBase<Builder, AIMovementRule>, IBuilder<AIMovementRule>
 		{
 			private AIMovementRule rule;
 
@@ -42,8 +42,7 @@ namespace Redninja.AI
 				return this;
 			}
 					
-
-			public AIMovementRule Build()
+			public override AIMovementRule Build()
 			{
 				BuildBase();
 				AIMovementRule builtRule = this.rule;

--- a/Redninja/AI/AIMovementRule.cs
+++ b/Redninja/AI/AIMovementRule.cs
@@ -1,12 +1,5 @@
 ﻿using Davfalcon.Revelator;
 using Redninja.Decisions;
-using Redninja.Skills;
-using Redninja.Targeting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/AIRuleBase.cs
+++ b/Redninja/AI/AIRuleBase.cs
@@ -1,12 +1,9 @@
 ﻿using Davfalcon.Revelator;
 using Redninja.Decisions;
-using Redninja.Skills;
 using Redninja.Targeting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/AIRuleBase.cs
+++ b/Redninja/AI/AIRuleBase.cs
@@ -16,7 +16,7 @@ namespace Redninja.AI
 	public abstract class AIRuleBase : IAIRule
 	{
 		// trigger conditions can rely on different targets
-		private List<Tuple<AITargetType, IAITargetCondition>> TriggerConditions { get; } = new List<Tuple<AITargetType, IAITargetCondition>>();
+		private List<Tuple<TargetTeam, IAITargetCondition>> TriggerConditions { get; } = new List<Tuple<TargetTeam, IAITargetCondition>>();
 
 		public string RuleName { get; private set; } = "Unnamed Rule";
 
@@ -54,7 +54,7 @@ namespace Redninja.AI
 			/// <param name="type"></param>
 			/// <param name="condition"></param>
 			/// <returns></returns>
-			public ParentBuilder AddTriggerCondition(AITargetType type, IAITargetCondition condition)
+			public ParentBuilder AddTriggerCondition(TargetTeam type, IAITargetCondition condition)
 			{
 				rule.TriggerConditions.Add(Tuple.Create(type, condition));
 				return this as ParentBuilder;
@@ -90,7 +90,7 @@ namespace Redninja.AI
 				if (rule.TriggerConditions.Count() == 0)
 				{
 					Logging.RLog.D(this, $"No conditions found for {rule.RuleName}, adding always true");
-					AddTriggerCondition(AITargetType.Self, AIConditionFactory.AlwaysTrue);
+					AddTriggerCondition(TargetTeam.Self, AIConditionFactory.AlwaysTrue);
 				}
 			}
 		}

--- a/Redninja/AI/AIRuleBase.cs
+++ b/Redninja/AI/AIRuleBase.cs
@@ -25,11 +25,11 @@ namespace Redninja.AI
 		public int RefreshTime { get; private set; }
 
 
-		public bool IsValidTriggerConditions(IBattleEntity source, IBattleEntityManager entityManager)
+		public bool IsValidTriggerConditions(IBattleEntity source, IDecisionHelper decisionHelper)
 		{
 			foreach(var trigger in TriggerConditions)
 			{
-				var validEntities = AIHelper.FilterByType(trigger.Item1, source, entityManager);
+				var validEntities = AIHelper.FilterByType(trigger.Item1, source, decisionHelper.BattleEntityManager);
 
 				if (validEntities.Count() == 0) return false; // couldnt find any targets to test triggers
 
@@ -40,12 +40,14 @@ namespace Redninja.AI
 			return true;			
 		}
 
-		public abstract IBattleAction GenerateAction(IBattleEntity source, IBattleEntityManager bem); 				
+		public abstract IBattleAction GenerateAction(IBattleEntity source, IDecisionHelper decisionHelper); 				
 
 		/// <summary>
 		/// Builder class for a rule.
 		/// </summary>
-		public abstract class BuilderBase<ParentBuilder> where ParentBuilder:BuilderBase<ParentBuilder>
+		public abstract class BuilderBase<ParentBuilder, T> : IBuilder<T>
+			where ParentBuilder:BuilderBase<ParentBuilder, T>
+			where T:AIRuleBase
 		{
 			private AIRuleBase rule;
 			
@@ -111,6 +113,8 @@ namespace Redninja.AI
 					AddTriggerCondition(TargetTeam.Self, AIConditionFactory.AlwaysTrue);
 				}
 			}
+
+			public abstract T Build();
 		}
 	}
 }

--- a/Redninja/AI/AIRuleFactory.cs
+++ b/Redninja/AI/AIRuleFactory.cs
@@ -1,9 +1,4 @@
 ﻿using Redninja.Targeting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/AIRuleFactory.cs
+++ b/Redninja/AI/AIRuleFactory.cs
@@ -7,10 +7,8 @@ using System.Threading.Tasks;
 
 namespace Redninja.AI
 {
-	public class AIRuleFactory
-	{
-		private AIRuleFactory() { }
-
+	public static class AIRuleFactory
+	{		
 		public static AISkillRule CreateAttackRule()
 			=> new AISkillRule.Builder()
 				.SetName("Attack")

--- a/Redninja/AI/AIRuleFactory.cs
+++ b/Redninja/AI/AIRuleFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Redninja.Targeting;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,7 +14,7 @@ namespace Redninja.AI
 		public static AISkillRule CreateAttackRule()
 			=> new AISkillRule.Builder()
 				.SetName("Attack")
-				.SetRuleTargetType(AITargetType.Enemy)
+				.SetRuleTargetType(TargetTeam.Enemy)
 				.SetWeight(1)				
 				.AddSkillAndPriority(null, AITargetPriorityFactory.NoPriority) // TODO
 				.Build();

--- a/Redninja/AI/AIRuleSet.cs
+++ b/Redninja/AI/AIRuleSet.cs
@@ -1,5 +1,6 @@
 ﻿using Davfalcon.Revelator;
 using Redninja.Decisions;
+using Redninja.Logging;
 using Redninja.Skills;
 using Redninja.Targeting;
 using System;
@@ -15,15 +16,29 @@ namespace Redninja.AI
 		// TODO add a default rule for standard attack to all rules, talk to rice about best course
 		private List<IAIRule> Rules { get; } = new List<IAIRule>();		
 
-		public IBattleAction ResolveAction(IBattleEntity source, IBattleEntityManager bem) 
+		/// <summary>
+		/// Resolve an action from these AI Rules. If no action can be found, it will return null.
+		/// </summary>
+		/// <param name="source"></param>
+		/// <param name="bem"></param>
+		/// <param name="historyState"></param>
+		/// <returns></returns>
+		public IBattleAction ResolveAction(IBattleEntity source, IBattleEntityManager bem, IAIHistoryState historyState) 
 		{
-			// TODO filter by refresh time so we dont repick the same skill by refresh requirement
+			// DEBUG rule name -> in pool
+			var debugRuleMeta = new Dictionary<string, bool>();
+			Rules.ForEach(x => debugRuleMeta[x.RuleName] = false);
+
 			// find rules triggers
 			IEnumerable<IAIRule> validRules = Rules.Where(rule => rule.IsValidTriggerConditions(source, bem));				
 
 			// assign pool
 			WeightedPool<IAIRule> weightedPool = new WeightedPool<IAIRule>();
-			validRules.ToList().ForEach(x => weightedPool.Add(x, x.Weight));			
+			foreach(var rule in validRules.Where(x => historyState.IsRuleReady(x)))
+			{
+				weightedPool.Add(rule, rule.Weight);
+				debugRuleMeta[rule.RuleName] = true;
+			}
 			
 			// cycle through rules until we find one we can assign
 			while(weightedPool.Count() > 0)
@@ -35,16 +50,24 @@ namespace Redninja.AI
 				
 				if(action != null)
 				{
+					LogResult(debugRuleMeta, rule, action);
+					historyState.AddEntry(rule, action);
 					return action;
 				}
 
 				// no targets found for any skill, prune and research
 				weightedPool.Remove(rule);
 			}
-
-			throw new InvalidProgramException("We couldnt find any rules to use, we should have implemented attack for all!");
+			LogResult(debugRuleMeta, null, null);
+			return null;
 		}
 
+		private void LogResult(Dictionary<string, bool> ruleMeta, IAIRule resolvedRule, IBattleAction resultAction)
+		{
+			string ruleStr = resolvedRule != null ? resolvedRule.RuleName : "NONE";
+			string actionStr = resultAction != null ? resultAction.GetType().ToString() : "NONE";
+			RLog.D(this, $"RuleSet - resultRule:{ruleStr} resultAction: {actionStr}\n\t{ruleMeta}");
+		}
 
 		public class Builder : IBuilder<AIRuleSet>
 		{
@@ -62,7 +85,9 @@ namespace Redninja.AI
 
 			public AIRuleSet Build()
 			{
-				return new AIRuleSet();
+				AIRuleSet builtSet = ruleSet;
+				Reset();
+				return builtSet;
 			}
 		}
 	}

--- a/Redninja/AI/AIRuleSet.cs
+++ b/Redninja/AI/AIRuleSet.cs
@@ -1,13 +1,8 @@
 ﻿using Davfalcon.Revelator;
 using Redninja.Decisions;
 using Redninja.Logging;
-using Redninja.Skills;
-using Redninja.Targeting;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/AIRuleSet.cs
+++ b/Redninja/AI/AIRuleSet.cs
@@ -23,14 +23,14 @@ namespace Redninja.AI
 		/// <param name="bem"></param>
 		/// <param name="historyState"></param>
 		/// <returns></returns>
-		public IBattleAction ResolveAction(IBattleEntity source, IBattleEntityManager bem, IAIHistoryState historyState) 
+		public IBattleAction ResolveAction(IBattleEntity source, IDecisionHelper decisionHelper, IAIHistoryState historyState) 
 		{
 			// DEBUG rule name -> in pool
 			var debugRuleMeta = new Dictionary<string, bool>();
-			Rules.ForEach(x => debugRuleMeta[x.RuleName] = false);
+			Rules.ForEach(x => debugRuleMeta[x.RuleName] = false);			
 
 			// find rules triggers
-			IEnumerable<IAIRule> validRules = Rules.Where(rule => rule.IsValidTriggerConditions(source, bem));				
+			IEnumerable<IAIRule> validRules = Rules.Where(rule => rule.IsValidTriggerConditions(source, decisionHelper));				
 
 			// assign pool
 			WeightedPool<IAIRule> weightedPool = new WeightedPool<IAIRule>();
@@ -46,7 +46,7 @@ namespace Redninja.AI
 				// pick weighted rule
 				IAIRule rule = weightedPool.Random();
 
-				IBattleAction action = rule.GenerateAction(source, bem);
+				IBattleAction action = rule.GenerateAction(source, decisionHelper);
 				
 				if(action != null)
 				{

--- a/Redninja/AI/AISkillRule.cs
+++ b/Redninja/AI/AISkillRule.cs
@@ -1,12 +1,9 @@
-﻿using Davfalcon.Revelator;
-using Redninja.Decisions;
+﻿using Redninja.Decisions;
 using Redninja.Skills;
 using Redninja.Targeting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/AISkillRule.cs
+++ b/Redninja/AI/AISkillRule.cs
@@ -17,7 +17,7 @@ namespace Redninja.AI
 	public class AISkillRule : AIRuleBase
 	{
 		// targeting who gets focused should be uniform for rule
-		private AITargetType TargetType { get; set; }
+		private TargetTeam TargetType { get; set; }
 		private List<IAITargetCondition> FilterConditions { get; } = new List<IAITargetCondition>();
 		private List<Tuple<IAITargetPriority, ICombatSkill>> SkillAssignments { get; } = new List<Tuple<IAITargetPriority, ICombatSkill>>();
 
@@ -90,7 +90,7 @@ namespace Redninja.AI
 		public class Builder : AIRuleBase.BuilderBase<Builder>, IBuilder<AISkillRule>
 		{
 			private AISkillRule rule;
-			private AITargetType? nullableType;
+			private TargetTeam? nullableType;
 
 			public Builder() => Reset();
 
@@ -107,7 +107,7 @@ namespace Redninja.AI
 			/// </summary>
 			/// <param name="type"></param>
 			/// <returns></returns>
-			public Builder SetRuleTargetType(AITargetType type)
+			public Builder SetRuleTargetType(TargetTeam type)
 			{
 				nullableType = type;
 				return this;

--- a/Redninja/AI/AITargetPriorityFactory.cs
+++ b/Redninja/AI/AITargetPriorityFactory.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.AI
 {

--- a/Redninja/AI/IAIHistoryState.cs
+++ b/Redninja/AI/IAIHistoryState.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Redninja.AI
+{
+	/// <summary>
+	/// History state to be passed to IAIRuleSet in order to record and check each
+	/// transaction.
+	/// </summary>
+	public interface IAIHistoryState : IClockSynchronized
+	{
+		void AddEntry(IAIRule rule, IBattleAction resolvedAction);
+		bool IsRuleReady(IAIRule rule);
+	}
+}

--- a/Redninja/AI/IAIRule.cs
+++ b/Redninja/AI/IAIRule.cs
@@ -8,7 +8,7 @@ namespace Redninja.AI
 		string RuleName { get; }
 		int Weight { get; }
 
-		IBattleAction GenerateAction(IBattleEntity source, IBattleEntityManager bemskillMeta);
-		bool IsValidTriggerConditions(IBattleEntity source, IBattleEntityManager entityManager);
+		IBattleAction GenerateAction(IBattleEntity source, IDecisionHelper decisionHelper);
+		bool IsValidTriggerConditions(IBattleEntity source, IDecisionHelper decisionHelper);
 	}
 }

--- a/Redninja/BattlePresenter.cs
+++ b/Redninja/BattlePresenter.cs
@@ -58,6 +58,7 @@ namespace Redninja
 			kernel.Bind<IBattleEntityManager>().To<BattleEntityManager>().InSingletonScope();
 			kernel.Bind<ICombatExecutor>().ToConstant(combatExecutor);
 			kernel.Bind<PlayerDecisionManager>().ToSelf().InSingletonScope();
+			kernel.Bind<IDecisionHelper>().To<DecisionHelper>().InSingletonScope();
 			kernel.Bind<IBattlePresenter>().To<BattlePresenter>().InSingletonScope();
 			kernel.Bind<IClock>().To<Clock>().InSingletonScope();
 			kernel.Bind<Clock>().ToSelf().InSingletonScope();

--- a/Redninja/Decisions/DecisionHelper.cs
+++ b/Redninja/Decisions/DecisionHelper.cs
@@ -12,12 +12,19 @@ namespace Redninja.Decisions
 	/// <summary>
 	/// Decision Manager for selecting a skill and a target to convert into an action.
 	/// </summary>
-	public static class DecisionHelper
+	public class DecisionHelper : IDecisionHelper
 	{
-		public static SkillSelectionMeta GetAvailableSkills(IBattleEntity entity)
+		public DecisionHelper(IBattleEntityManager manager)
+		{
+			BattleEntityManager = manager;
+		}
+
+		public IBattleEntityManager BattleEntityManager { get; }
+
+		public IActionPhaseHelper GetAvailableSkills(IBattleEntity entity)
 			=> new SkillSelectionMeta(entity, entity.Skills);
 
-		public static ISkillTargetingManager GetTargetingManager(IBattleEntity entity, IBattleEntityManager entityManager, ICombatSkill combatSkill)
-			=> new SkillTargetMeta(entity, combatSkill, entityManager);
+		public ITargetPhaseHelper GetTargetingManager(IBattleEntity entity, ICombatSkill combatSkill)
+			=> new SkillTargetMeta(entity, combatSkill, BattleEntityManager);
 	}
 }

--- a/Redninja/Decisions/IActionPhaseHelper.cs
+++ b/Redninja/Decisions/IActionPhaseHelper.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Redninja.Skills;
+
+namespace Redninja.Decisions
+{
+	public interface IActionPhaseHelper
+	{
+		IBattleEntity Entity { get; }
+		IEnumerable<ICombatSkill> Skills { get; }
+	}
+}

--- a/Redninja/Decisions/IDecisionHelper.cs
+++ b/Redninja/Decisions/IDecisionHelper.cs
@@ -1,0 +1,16 @@
+﻿using Redninja.Skills;
+
+namespace Redninja.Decisions
+{
+	/// <summary>
+	/// This helper will provide instances that represent the state of processing the
+	/// requirement for finishing a turn by deciding a skill and targets.
+	/// </summary>
+	public interface IDecisionHelper
+	{
+		IBattleEntityManager BattleEntityManager { get; }
+
+		IActionPhaseHelper GetAvailableSkills(IBattleEntity entity);
+		ITargetPhaseHelper GetTargetingManager(IBattleEntity entity, ICombatSkill combatSkill);
+	}
+}

--- a/Redninja/Decisions/ITargetPhaseHelper.cs
+++ b/Redninja/Decisions/ITargetPhaseHelper.cs
@@ -2,7 +2,7 @@
 
 namespace Redninja.Decisions
 {
-	public interface ISkillTargetingManager : ISkillTargetingInfo
+	public interface ITargetPhaseHelper : ISkillTargetingInfo
 	{
 		void SelectTarget(ISelectedTarget target);
 		bool Back();

--- a/Redninja/Decisions/PlayerDecisionManager.cs
+++ b/Redninja/Decisions/PlayerDecisionManager.cs
@@ -5,12 +5,12 @@ using Redninja.Targeting;
 namespace Redninja.Decisions
 {
 	public class PlayerDecisionManager : IActionDecider
-	{
-		private readonly IBattleEntityManager entityManager;
+	{		
 		private readonly IBattleView view;
+		private readonly IDecisionHelper decisionHelper;
 
 		private IBattleEntity blockingEntity;
-		private ISkillTargetingManager currentSkill;
+		private ITargetPhaseHelper currentSkill;
 
 		bool IActionDecider.IsPlayer => true;
 
@@ -18,9 +18,9 @@ namespace Redninja.Decisions
 		public event Action<IBattleEntity> WaitingForDecision;
 		public event Action WaitResolved;
 
-		public PlayerDecisionManager(IBattleEntityManager entityManager, IBattleView view)
+		public PlayerDecisionManager(IBattleView view, IDecisionHelper decisionHelper)
 		{
-			this.entityManager = entityManager;
+			this.decisionHelper = decisionHelper;			
 			this.view = view;
 
 			view.ActionSelected += OnActionSelected;
@@ -50,7 +50,7 @@ namespace Redninja.Decisions
 		{
 			if (currentSkill != null) throw new InvalidOperationException("Targeting should be canceled before another skill can be selected.");
 
-			currentSkill = DecisionHelper.GetTargetingManager(entity, entityManager, skill);
+			currentSkill = decisionHelper.GetTargetingManager(entity, skill);
 			view.SetViewModeTargeting(currentSkill);
 		}
 

--- a/Redninja/Decisions/SkillSelectionMeta.cs
+++ b/Redninja/Decisions/SkillSelectionMeta.cs
@@ -6,7 +6,7 @@ namespace Redninja.Decisions
 	/// <summary>
 	/// Result for requesting what available skills a entity can use.
 	/// </summary>
-	public class SkillSelectionMeta
+	public class SkillSelectionMeta : IActionPhaseHelper
 	{
 		public IEnumerable<ICombatSkill> Skills { get; }
 		public IBattleEntity Entity { get; }

--- a/Redninja/Decisions/SkillTargetMeta.cs
+++ b/Redninja/Decisions/SkillTargetMeta.cs
@@ -8,7 +8,7 @@ using Redninja.Targeting;
 
 namespace Redninja.Decisions
 {
-	public class SkillTargetMeta : ISkillTargetingManager
+	public class SkillTargetMeta : ITargetPhaseHelper
 	{
 		private readonly IBattleEntityManager entityManager;
 		private readonly IEnumerable<SkillResolver>[] skillResolvers;

--- a/Redninja/Properties/AssemblyInfo.cs
+++ b/Redninja/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("Redninja.UnitTests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Redninja/Redninja.csproj
+++ b/Redninja/Redninja.csproj
@@ -69,8 +69,10 @@
     <Compile Include="AI\IAITargetPriority.cs" />
     <Compile Include="AI\WeightedPool.cs" />
     <Compile Include="Coordinate.cs" />
+    <Compile Include="Decisions\IActionPhaseHelper.cs" />
+    <Compile Include="Decisions\IDecisionHelper.cs" />
     <Compile Include="Decisions\ISkillTargetingInfo.cs" />
-    <Compile Include="Decisions\ISkillTargetingManager.cs" />
+    <Compile Include="Decisions\ITargetPhaseHelper.cs" />
     <Compile Include="Decisions\PlayerDecisionManager.cs" />
     <Compile Include="Decisions\SkillSelectionMeta.cs" />
     <Compile Include="Decisions\SkillTargetMeta.cs" />

--- a/Redninja/Redninja.csproj
+++ b/Redninja/Redninja.csproj
@@ -63,6 +63,7 @@
     <Compile Include="AI\AIRuleFactory.cs" />
     <Compile Include="AI\AIRuleSet.cs" />
     <Compile Include="AI\AITargetPriorityFactory.cs" />
+    <Compile Include="AI\IAIHistoryState.cs" />
     <Compile Include="AI\IAIRule.cs" />
     <Compile Include="AI\IAITargetCondition.cs" />
     <Compile Include="AI\IAITargetPriority.cs" />


### PR DESCRIPTION
* Added **WeightedPool<T>** tests
* Added a few AI tests
* fixed some discovered issues with the tests
* the **AISkillRule** is painfully complex with logic so attempting to break it out in order to back with tests.
* moved the **DecisionHelper** back to an instance class generated by the **Kernel** and made its sub components also interface classes to be mocked.
* subcomponents of the **IDecisionManager** are named **IActionPhaseHelper** and **ITargetPhaseHelper** with dire need of better names.
* replaced the **IDecisionHelper** in a few places that previously had **IBattleEntityManager**.
* removed **AITargetType** to reuse **TargetTeam**