### PR TITLE
skills/movement scaffolding

### DIFF
--- a/Redninja.Console/Objects/CombatSkills.cs
+++ b/Redninja.Console/Objects/CombatSkills.cs
@@ -7,18 +7,16 @@ namespace Redninja.ConsoleDriver.Objects
 {
 	public static class CombatSkills
 	{
-		public static ISkill BasicAttack { get; } = new WeaponAttack.Builder()
+		public static ISkill BasicAttack { get; } = WeaponAttack.Build(b => b
 			.SetActionTime(2, 2, 2)
-			.AddWeapon(Weapons.Sword)
-			.Build();
+			.AddWeapon(Weapons.Sword));
 
-		public static ISkill TwoHandedAttack { get; } = new WeaponAttack.Builder()
+		public static ISkill TwoHandedAttack { get; } = WeaponAttack.Build(b => b
 			.SetActionTime(3, 2, 3)
 			.AddWeapon(Weapons.Shortsword)
-			.AddWeapon(Weapons.Dagger)
-			.Build();
+			.AddWeapon(Weapons.Dagger));
 
-		public static ISkill TargetedSkill { get; } = new CombatSkill.Builder()
+		public static ISkill TargetedSkill { get; } = CombatSkill.Build(b => b
 			.SetName("Targeted skill")
 			.SetActionTime(5, 10, 2)
 			.SetDamage(40)
@@ -28,10 +26,9 @@ namespace Redninja.ConsoleDriver.Objects
 				.AddCombatRound(0.2f, (e, t, s) => new DamageOperation(e, t, s))
 				.AddCombatRound(0.4f, (e, t, s) => new DamageOperation(e, t, s))
 				.AddCombatRound(0.8f, (e, t, s) => new DamageOperation(e, t, s))
-			)
-			.Build();
+			));
 
-		public static ISkill PatternSkill { get; } = new CombatSkill.Builder()
+		public static ISkill PatternSkill { get; } = CombatSkill.Build(b => b
 			.SetName("Pattern skill")
 			.SetActionTime(7, 5, 10)
 			.SetDamage(20)
@@ -43,7 +40,6 @@ namespace Redninja.ConsoleDriver.Objects
 				.AddCombatRound(0.55f, TargetPatternFactory.CreateRowPattern(1), (e, t, s) => new DamageOperation(e, t, s))
 				.AddCombatRound(0.75f, TargetPatternFactory.CreateRowPattern(2), (e, t, s) => new DamageOperation(e, t, s))
 				.AddCombatRound(0.8f, TargetPatternFactory.CreateRowPattern(2), (e, t, s) => new DamageOperation(e, t, s))
-			)
-			.Build();
+			));
 	}
 }

--- a/Redninja.Console/Objects/Weapons.cs
+++ b/Redninja.Console/Objects/Weapons.cs
@@ -5,22 +5,19 @@ namespace Redninja.ConsoleDriver.Objects
 {
 	public static class Weapons
 	{
-		public static IWeapon Sword { get; } = new Weapon.Builder(EquipmentType.Weapon, WeaponType.Sword)
+		public static IWeapon Sword { get; } = Weapon.Build(EquipmentType.Weapon, WeaponType.Sword, b => b
 			.SetName("Longsword")
 			.SetDamage(20)
-			.AddDamageType(DamageType.Physical)
-			.Build();
+			.AddDamageType(DamageType.Physical));
 
-		public static IWeapon Shortsword { get; } = new Weapon.Builder(EquipmentType.Weapon, WeaponType.Sword)
+		public static IWeapon Shortsword { get; } = Weapon.Build(EquipmentType.Weapon, WeaponType.Sword, b => b
 			.SetName("Shortsword")
 			.SetDamage(10)
-			.AddDamageType(DamageType.Physical)
-			.Build();
+			.AddDamageType(DamageType.Physical));
 
-		public static IWeapon Dagger { get; } = new Weapon.Builder(EquipmentType.Weapon, WeaponType.Dagger)
+		public static IWeapon Dagger { get; } = Weapon.Build(EquipmentType.Weapon, WeaponType.Dagger, b => b
 			.SetName("Dagger")
 			.SetDamage(5)
-			.AddDamageType(DamageType.Physical)
-			.Build();
+			.AddDamageType(DamageType.Physical));
 	}
 }

--- a/Redninja.Console/Program.cs
+++ b/Redninja.Console/Program.cs
@@ -22,27 +22,23 @@ namespace Redninja.ConsoleDriver
 				.AddVolatileStat(CombatStats.HP));
 
 			IBattlePresenter presenter = BattlePresenter.CreatePresenter(view, executor);
-			presenter.AddCharacter(
-				new Unit.Builder(StatsOperations.Default, LinkedStatsResolver.Default)
+			presenter.AddCharacter(b => b
 				.SetMainDetails("Unit 1")
 				.SetBaseStat(CombatStats.HP, 100)
 				.SetBaseStat(CombatStats.ATK, 50)
 				.SetBaseStat(CombatStats.DEF, 10),
 				0, 0);
-			presenter.AddCharacter(
-				new Unit.Builder()
+			presenter.AddCharacter(b => b
 				.SetMainDetails("Enemy 1")
 				.SetBaseStat(CombatStats.HP, 1000)
 				.SetBaseStat(CombatStats.DEF, 10),
 				new DummyAI(), 1, 0, 0);
-			presenter.AddCharacter(
-				new Unit.Builder()
+			presenter.AddCharacter(b => b
 				.SetMainDetails("Enemy 2")
 				.SetBaseStat(CombatStats.HP, 1000)
 				.SetBaseStat(CombatStats.DEF, 20),
 				new DummyAI(), 1, 1, 0);
-			presenter.AddCharacter(
-				new Unit.Builder()
+			presenter.AddCharacter(b => b
 				.SetMainDetails("Enemy 3")
 				.SetBaseStat(CombatStats.HP, 1000)
 				.SetBaseStat(CombatStats.DEF, 30),

--- a/Redninja/BattlePresenter.cs
+++ b/Redninja/BattlePresenter.cs
@@ -116,6 +116,10 @@ namespace Redninja
 		public void Dispose()
 		{
 			kernel.Dispose();
+			foreach (IBattleEntity entity in entityManager.AllEntities)
+			{
+				entity.Dispose();
+			}
 		}
 
 		private void AddBattleEntity(IBattleEntity entity)
@@ -137,11 +141,11 @@ namespace Redninja
 			AddBattleEntity(entity);
 		}
 
-		public void AddCharacter(IBuilder<IUnit> builder, int row, int col)
-			=> AddCharacter(builder.Build(), row, col);
+		public void AddCharacter(Func<Unit.Builder, IBuilder<IUnit>> builderFunc, int row, int col)
+			=> AddCharacter(Unit.Build(builderFunc), row, col);
 
-		public void AddCharacter(IBuilder<IUnit> builder, IActionDecider actionDecider, int team, int row, int col)
-			=> AddCharacter(builder.Build(), actionDecider, team, row, col);
+		public void AddCharacter(Func<Unit.Builder, IBuilder<IUnit>> builderFunc, IActionDecider actionDecider, int team, int row, int col)
+			=> AddCharacter(Unit.Build(builderFunc), actionDecider, team, row, col);
 
 		/// <summary>
 		/// Update game clock. This drives the presenter.

--- a/Redninja/Decisions/DecisionHelper.cs
+++ b/Redninja/Decisions/DecisionHelper.cs
@@ -1,11 +1,4 @@
-﻿using Redninja.Targeting;
-using Redninja.Skills;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Redninja.Actions;
+﻿using Redninja.Skills;
 
 namespace Redninja.Decisions
 {

--- a/Redninja/IBattleEntity.cs
+++ b/Redninja/IBattleEntity.cs
@@ -15,7 +15,7 @@ namespace Redninja
 		PhaseState Phase { get; }
 		float PhasePercent { get; }
 		IActionDecider ActionDecider { get; set; }
-		List<ISkill> Skills { get; }
+		IEnumerable<ISkill> Skills { get; }
 
 		event Action<IBattleEntity> DecisionRequired;
 

--- a/Redninja/IBattlePresenter.cs
+++ b/Redninja/IBattlePresenter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Davfalcon.Builders;
 using Davfalcon.Revelator;
 
@@ -9,8 +8,8 @@ namespace Redninja
 	{
 		void AddCharacter(IUnit character, int row, int col);
 		void AddCharacter(IUnit character, IActionDecider actionDecider, int team, int row, int col);
-		void AddCharacter(IBuilder<IUnit> builder, int row, int col);
-		void AddCharacter(IBuilder<IUnit> builder, IActionDecider actionDecider, int team, int row, int col);
+		void AddCharacter(Func<Unit.Builder, IBuilder<IUnit>> builderFunc, int row, int col);
+		void AddCharacter(Func<Unit.Builder, IBuilder<IUnit>> builderFunc, IActionDecider actionDecider, int team, int row, int col);
 		void IncrementGameClock(float timeDelta);
 		void Initialize();
 		void Start();

--- a/Redninja/Redninja.csproj
+++ b/Redninja/Redninja.csproj
@@ -102,6 +102,8 @@
     <Compile Include="IBattleEvent.cs" />
     <Compile Include="IBattleOperation.cs" />
     <Compile Include="IBattleView.cs" />
+    <Compile Include="Skills\ISkillProvider.cs" />
+    <Compile Include="Skills\IWeaponAttack.cs" />
     <Compile Include="Skills\WeaponAttack.cs" />
     <Compile Include="Skills\CombatSkill.cs" />
     <Compile Include="Skills\ISkillResolver.cs" />

--- a/Redninja/Skills/CombatSkill.cs
+++ b/Redninja/Skills/CombatSkill.cs
@@ -32,14 +32,14 @@ namespace Redninja.Skills
 			return new SkillAction(entity, this, resolvers);
 		}
 
+		public static ISkill Build(Func<Builder, IBuilder<ISkill>> func)
+			=> func(new Builder()).Build();
+
 		public class Builder : BuilderBase<CombatSkill, ISkill, Builder>
 		{
 			private List<SkillTargetingSet> targets;
 
-			public Builder()
-			{
-				Reset();
-			}
+			public Builder() => Reset();
 
 			public override Builder Reset()
 			{

--- a/Redninja/Skills/ISkillProvider.cs
+++ b/Redninja/Skills/ISkillProvider.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Davfalcon.Revelator;
+
+namespace Redninja.Skills
+{
+	public interface ISkillProvider
+	{
+		IWeaponAttack GetAttack(string className, IEnumerable<IWeapon> weapons);
+		IEnumerable<ISkill> GetSkills(string className, int level);
+	}
+}

--- a/Redninja/Skills/IWeaponAttack.cs
+++ b/Redninja/Skills/IWeaponAttack.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Davfalcon.Revelator;
+
+namespace Redninja.Skills
+{
+	public interface IWeaponAttack : ISkill
+	{
+		IEnumerable<IWeapon> Weapons { get; }
+	}
+}

--- a/Redninja/Skills/SkillTargetingSet.cs
+++ b/Redninja/Skills/SkillTargetingSet.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Davfalcon.Builders;
 using Redninja.Targeting;
@@ -25,12 +26,15 @@ namespace Redninja.Skills
 			TargetingRule = targetingRule;
 		}
 
+		public static SkillTargetingSet Build(ITargetingRule targetingRule, Func<Builder, IBuilder<SkillTargetingSet>> func)
+			=> func(new Builder(targetingRule)).Build();
+
 		public class Builder : BuilderBase<SkillTargetingSet, Builder>
 		{
 			private readonly ITargetingRule targetingRule;
 			private List<SkillOperationDefinition> rounds;
 
-			public Builder(ITargetingRule targetingRule)
+			internal Builder(ITargetingRule targetingRule)
 			{
 				this.targetingRule = targetingRule;
 				Reset();

--- a/Redninja/Skills/WeaponAttack.cs
+++ b/Redninja/Skills/WeaponAttack.cs
@@ -7,12 +7,13 @@ using Redninja.Targeting;
 
 namespace Redninja.Skills
 {
-	public class WeaponAttack : ISkill
+	public class WeaponAttack : ISkill, IWeaponAttack
 	{
 		private readonly List<IWeapon> weapons = new List<IWeapon>();
 
 		public string Name => "Basic attack";
 		public ActionTime Time { get; private set; }
+		public IEnumerable<IWeapon> Weapons { get; private set; }
 		public IReadOnlyList<SkillTargetingSet> Targets { get; private set; }
 
 		public int BaseDamage => weapons[0].BaseDamage;
@@ -47,7 +48,8 @@ namespace Redninja.Skills
 				build = new WeaponAttack
 				{
 					// Need to add weapon range later
-					Targets = new List<SkillTargetingSet>() { new SkillTargetingSet(new TargetingRule(TargetTeam.Enemy)) }.AsReadOnly()
+					Targets = new List<SkillTargetingSet>() { new SkillTargetingSet(new TargetingRule(TargetTeam.Enemy)) }.AsReadOnly(),
+					Weapons = build.weapons.AsReadOnly()
 				};
 				return Builder;
 			}

--- a/Redninja/Skills/WeaponAttack.cs
+++ b/Redninja/Skills/WeaponAttack.cs
@@ -34,6 +34,9 @@ namespace Redninja.Skills
 			return new SkillAction(entity, this, resolvers);
 		}
 
+		public static ISkill Build(Func<Builder, IBuilder<ISkill>> func)
+			=> func(new Builder()).Build();
+
 		public class Builder : BuilderBase<WeaponAttack, ISkill, Builder>
 		{
 			public Builder()


### PR DESCRIPTION
Some basic scaffolding for movement targeting within the PlayerDecisionManager.
MovementComponent implementation not yet complete, pending implementation of class definitions/data store.

Also added weapon attack construction to BattleEntity, but I feel like it shouldn't be there or in the DecisionHelper, since we will want to view skills/attack details outside of battle too.

Also wrapped some builder constructions in static methods.