### PR TITLE
replace linq FirstOrDefault with Any or All where applicable

### DIFF
--- a/Redninja/Components/Decisions/AI/AIExecutor.cs
+++ b/Redninja/Components/Decisions/AI/AIExecutor.cs
@@ -88,14 +88,15 @@ namespace Redninja.Components.Decisions.AI
 			action = null;
 			return false;
 		}
-		
+
+
 		internal virtual bool IsValidTriggerConditions(IAIRule rule)
 		{
 			foreach (var trigger in rule.TriggerConditions)
 			{
 				var validEntities = FilterByType(trigger.Item1);				
 
-				bool foundValid = null != validEntities.FirstOrDefault(ex => trigger.Item2.IsValid(ex));
+				bool foundValid = validEntities.Any(trigger.Item2.IsValid);
 
 				if (!foundValid) return false;
 			}
@@ -169,7 +170,7 @@ namespace Redninja.Components.Decisions.AI
 			leftoverTargets = leftoverTargets.Where(ex => targetingRule.IsValidTarget(ex, source));
 
 			// filter by filter conditions (exclude by finding first condition that fails)
-			leftoverTargets = leftoverTargets.Where(ex => rule.FilterConditions.FirstOrDefault(cond => !cond.IsValid(ex)) == null);
+			leftoverTargets = leftoverTargets.Where(ex => rule.FilterConditions.All(cond => cond.IsValid(ex)));
 			return leftoverTargets;
 		}
 		#endregion

--- a/Redninja/Components/Decisions/AI/WeightedPool.cs
+++ b/Redninja/Components/Decisions/AI/WeightedPool.cs
@@ -19,7 +19,7 @@ namespace Redninja.Components.Decisions.AI
 
 		public void Add(T item, double weight)
 		{
-			if (items.FirstOrDefault(x => x.Item1.Equals(item)) != null) throw new InvalidOperationException($"Cannot add the same item: {item}");
+			if (items.Any(x => x.Item1.Equals(item))) throw new InvalidOperationException($"Cannot add the same item: {item}");
 			items.Add(new Tuple<T, double>(item, weight));
 			TotalWeight += weight;
 		}


### PR DESCRIPTION
At first i was like, I should make a helper method that does this. Then I wrote a test behind it, then as i was writing my test the IDE on the mac goes 'you should try `Any()`..