### PR TITLE
integrate AI for attack skills so that they are always chosen

### DIFF
--- a/Redninja.Console/Assets/Data/ai_behaviors.json
+++ b/Redninja.Console/Assets/Data/ai_behaviors.json
@@ -3,6 +3,7 @@
     "dataid": "goblin_priest",
     "ruleIds": [
       "attack_enemy",
+      "fire_enemy",
       "heal_self"
     ]
   },

--- a/Redninja.Console/Assets/Data/ai_rules.json
+++ b/Redninja.Console/Assets/Data/ai_rules.json
@@ -1,27 +1,25 @@
 ﻿{
   "skillRules": [
     {
-      "dataId": "attack_enemy",
-      "ruleName": "Attack Enemy",
+      "dataId": "fire_enemy",     
       "refreshTime": 0,
       "weight": 1,
       "triggerConditions": {},
       "filterConditions": [],
       "skillPriorityMap": {
-        "attack": "Any"
+        "fire_skill": "Any"
       },
       "targetType": "Enemy"
     },
 
     {
       "dataId": "heal_self",
-      "ruleName": "Heal self",
-      "refreshTime": 0,
+      "refreshTime": 10,
       "weight": 1,
       "triggerConditions": {
         "Self": [
           "HP < 50%",
-          "Resource > 50" 
+          "Resource > 50"
         ]
       },
       "filterConditions": [],
@@ -29,6 +27,15 @@
         "heal_self": "Any"
       },
       "targetType": "Self"
+    }
+  ],
+  "attackRules": [
+    {
+      "dataId": "attack_enemy",
+      "refreshTime": 0,
+      "weight": 1,
+      "triggerConditions": {},
+      "priority": "Any"
     }
   ]
 }

--- a/Redninja.Console/Assets/Data/skills.json
+++ b/Redninja.Console/Assets/Data/skills.json
@@ -1,13 +1,13 @@
 ﻿{
   "combatSkills": [
     {
-      "dataId": "attack",
-      "name": "skill",
+      "dataId": "fire_skill",
+      "name": "Fire",
       "time": [ 3, 1, 2 ],
       "defaultParameters": {
         "baseDamage": 10,
         "critMultiplier": 2,
-        "damageTypes": [ "Physical" ]
+        "damageTypes": [ "Magical" ]
       },
       "targetingSets": [
         {

--- a/Redninja.Console/Program.cs
+++ b/Redninja.Console/Program.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using Davfalcon.Revelator.Borger;
 using Redninja.Data;
+using Redninja.Logging;
 using Redninja.Presenter;
 using static Redninja.Data.Encounter;
 
@@ -13,6 +15,7 @@ namespace Redninja.ConsoleDriver
 
 		static void Main(string[] args)
 		{
+			InstallLogger();
 			ConsoleView view = new ConsoleView();
 
 			IDataManager dataManager = DataManagerFactory.Create(CONFIG_FILE_PATH);
@@ -63,6 +66,24 @@ namespace Redninja.ConsoleDriver
 				view.Draw();
 				Thread.Sleep(100);
 			}
+		}
+
+		private static void InstallLogger()
+		{
+			RLog.AppendPrinter((string tag, object msg, RLog.LogType logtype) =>
+			{
+				string text = $"[{tag}] {msg}";
+				switch (logtype)
+				{
+					case RLog.LogType.ERROR:
+						Debug.Fail(text);
+						break;
+
+					default:
+						Debug.WriteLine(text);
+						break;
+				}
+			});
 		}
 	}
 }

--- a/Redninja.UnitTests/Components/Decisions/AI/AIExecutorTests.cs
+++ b/Redninja.UnitTests/Components/Decisions/AI/AIExecutorTests.cs
@@ -159,7 +159,7 @@ namespace Redninja.Components.Decisions.AI.UnitTests
 			subject.When(x => x.FilterByType(Arg.Any<TargetTeam>())).DoNotCallBase();
 			subject.FilterByType(Arg.Any<TargetTeam>()).Returns(x => originalEntities);
 
-			var result = subject.GetValidTargets(mRule, mTargetingRule);
+			var result = subject.GetValidSkillTargets(mRule, mTargetingRule);
 
 			Assert.That(result, Is.EquivalentTo(expectedEntities));
 		}

--- a/Redninja.UnitTests/Components/Decisions/AI/AISkillRuleTests.cs
+++ b/Redninja.UnitTests/Components/Decisions/AI/AISkillRuleTests.cs
@@ -12,7 +12,7 @@ using Redninja.Components.Targeting;
 namespace Redninja.Components.Decisions.AI.UnitTests
 {
 	[TestFixture]
-	public class AISkillRuleTests : AIRuleBaseTests<AISkillRule.Builder, AISkillRule>
+	internal class AISkillRuleTests : AIRuleBaseTests<AISkillRule.Builder, AISkillRule>
 	{			
 		private AISkillRule.Builder subjectBuilder;
 

--- a/Redninja.UnitTests/GlobalEnvironment.cs
+++ b/Redninja.UnitTests/GlobalEnvironment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using NUnit.Framework;
 using Redninja.Logging;
 
@@ -11,15 +12,15 @@ namespace Redninja.UnitTests
 		public void InitLogger() {
 			RLog.AppendPrinter((string tag, object msg, RLog.LogType logtype) =>
 			{
-				string text = $"[{tag}] $msg";
+				string text = $"[{tag}] {msg}";
 				switch (logtype)
 				{
 					case RLog.LogType.ERROR:
-						Console.Error.WriteLine(text);
+						Debug.Fail(text);
 						break;
 					
 					default:
-						Console.WriteLine(text);
+						Debug.WriteLine(text);
 						break;
 				}
 			});

--- a/Redninja/Components/Decisions/AI/AIAttackRule.cs
+++ b/Redninja/Components/Decisions/AI/AIAttackRule.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Redninja.Components.Decisions.AI
+{
+	internal class AIAttackRule : AIRuleBase, IAIAttackRule
+	{
+		public IAITargetPriority TargetPriority { get; private set; }
+
+		public class Builder : BuilderBase<Builder, AIAttackRule>
+		{
+			private AIAttackRule rule;			
+
+			public Builder() => Reset();
+
+			public override AIAttackRule Build()
+			{
+				if (rule.TargetPriority == null) throw new InvalidOperationException($"Missing IAITargetProperity");
+				BuildBase();
+				AIAttackRule builtRule = this.rule;
+				Reset();
+				return builtRule;
+			}
+
+			public Builder SetTargetPriority(IAITargetPriority priority)
+			{
+				rule.TargetPriority = priority;
+				return this;
+			}
+
+			public Builder Reset()
+			{
+				rule = new AIAttackRule();				
+				ResetBase(rule);
+				return this;
+			}
+		}
+	}
+}

--- a/Redninja/Components/Decisions/AI/AIBehavior.cs
+++ b/Redninja/Components/Decisions/AI/AIBehavior.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Davfalcon.Builders;
 
 namespace Redninja.Components.Decisions.AI
@@ -19,7 +20,13 @@ namespace Redninja.Components.Decisions.AI
 				return this;
 			}
 
-			public void AddRule(IAIRule rule) => ruleSet.Rules.Add(rule);
+			private Builder Self(Action<Builder> action)
+			{
+				action(this);
+				return this;
+			}
+
+			public void AddRule(IAIRule rule) => Self(x => ruleSet.Rules.Add(rule));
 
 			public AIBehavior Build()
 			{

--- a/Redninja/Components/Decisions/AI/AIExecutor.cs
+++ b/Redninja/Components/Decisions/AI/AIExecutor.cs
@@ -182,7 +182,6 @@ namespace Redninja.Components.Decisions.AI
 
 			ITargetingContext targetMeta = decisionHelper.GetTargetingContext(source, skillMeta.Attack);
 			
-			
 			IEnumerable<IUnitModel> leftoverTargets = FilterByType(TargetTeam.Enemy);			
 			leftoverTargets = leftoverTargets.Where(ex => TargetConditions.MustBeAlive(ex, source));
 

--- a/Redninja/Components/Decisions/AI/AIRuleFactory.cs
+++ b/Redninja/Components/Decisions/AI/AIRuleFactory.cs
@@ -2,15 +2,13 @@
 
 namespace Redninja.Components.Decisions.AI
 {
-	public static class AIRuleFactory
+	internal static class AIRuleFactory
 	{		
-		public static AISkillRule CreateAttackRule()
-			=> new AISkillRule.Builder()
-				.SetName("Attack")
-				.SetRuleTargetType(TargetTeam.Enemy)
+		public static AIAttackRule CreateDefaultAttackRule()
+			=> new AIAttackRule.Builder()				
+				.SetName("Attack")			
 				.SetWeight(1)				
-				.AddSkillAndPriority(null, AITargetPriorityFactory.Any) // TODO
-				.Build();
-		
+				.SetTargetPriority(AITargetPriorityFactory.Any) 
+				.Build();		
 	}
 }

--- a/Redninja/Components/Decisions/AI/AISkillRule.cs
+++ b/Redninja/Components/Decisions/AI/AISkillRule.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Redninja.Components.Actions;
 using Redninja.Components.Skills;
 using Redninja.Components.Targeting;
 
@@ -11,7 +10,7 @@ namespace Redninja.Components.Decisions.AI
 	/// This represents a set of conditions that may be attached to a list of
 	/// actionable items. All skills in this rule should be unique.
 	/// </summary>
-	public class AISkillRule : AIRuleBase, IAISkillRule
+	internal class AISkillRule : AIRuleBase, IAISkillRule
 	{
 		// targeting who gets focused should be uniform for rule
 		public TargetTeam TargetType { get; private set; }

--- a/Redninja/Components/Decisions/AI/IAIAttackRule.cs
+++ b/Redninja/Components/Decisions/AI/IAIAttackRule.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Redninja.Components.Decisions.AI
+{
+	public interface IAIAttackRule
+	{
+		IAITargetPriority TargetPriority { get; }
+	}
+}

--- a/Redninja/Components/Decisions/IDecisionHelper.cs
+++ b/Redninja/Components/Decisions/IDecisionHelper.cs
@@ -12,6 +12,6 @@ namespace Redninja.Components.Decisions
 
 		IMovementContext GetMovementContext(IUnitModel entity);
 		IActionsContext GetActionsContext(IUnitModel entity);
-		ITargetingContext GetTargetingContext(IUnitModel entity, ISkill skill);
+		ITargetingContext GetTargetingContext(IUnitModel entity, ISkill skill);		
 	}
 }

--- a/Redninja/Components/Targeting/TargetingRule.cs
+++ b/Redninja/Components/Targeting/TargetingRule.cs
@@ -47,5 +47,7 @@ namespace Redninja.Components.Targeting
 			=> condition(target, user);
 
 		public static ITargetingRule Any { get; } = new TargetingRule(TargetTeam.Any);
+
+		public static ITargetingRule Alive { get; } = new TargetingRule(TargetTeam.Enemy, TargetConditions.MustBeAlive);
 	}
 }

--- a/Redninja/Data/Schema/AIAttackRuleSchema.cs
+++ b/Redninja/Data/Schema/AIAttackRuleSchema.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using Redninja.Components.Targeting;
+
+namespace Redninja.Data.Schema
+{
+	[Serializable]
+	internal class AIAttackRuleSchema : IDataSource
+	{
+		public string DataId { get; set; }
+		public int RefreshTime { get; set; }
+		public int Weight { get; set; }
+		public string Priority { get; set; }
+
+		public Dictionary<TargetTeam, List<string>> TriggerConditions { get; set; }		
+	}	
+
+	
+}

--- a/Redninja/Data/Schema/AIRulesRootSchema.cs
+++ b/Redninja/Data/Schema/AIRulesRootSchema.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Redninja.Data.Schema
 {
@@ -10,5 +7,6 @@ namespace Redninja.Data.Schema
 	internal class AIRulesRootSchema
 	{
 		public List<AISkillRuleSchema> SkillRules { get; set; }
+		public List<AIAttackRuleSchema> AttackRules { get; set; }
 	}
 }

--- a/Redninja/Data/Schema/AISkillRuleSchema.cs
+++ b/Redninja/Data/Schema/AISkillRuleSchema.cs
@@ -8,7 +8,6 @@ namespace Redninja.Data.Schema
 	internal class AISkillRuleSchema : IDataSource
 	{
 		public string DataId { get; set; }
-		public string RuleName { get; set; }
 		public int RefreshTime { get; set; }
 		public int Weight { get; set; }
 

--- a/Redninja/Redninja.csproj
+++ b/Redninja/Redninja.csproj
@@ -53,8 +53,10 @@
     <Compile Include="Components\Clock\Clock.cs" />
     <Compile Include="Components\Combat\Events\StatusEffectEvent.cs" />
     <Compile Include="Components\Combat\StatusEffectOperation.cs" />
+    <Compile Include="Components\Decisions\AI\AIAttackRule.cs" />
     <Compile Include="Components\Decisions\AI\AIExecutor.cs" />
     <Compile Include="Components\Decisions\AI\AIRuleTracker.cs" />
+    <Compile Include="Components\Decisions\AI\IAIAttackRule.cs" />
     <Compile Include="Components\Decisions\AI\IAISkillRule.cs" />
     <Compile Include="Components\Decisions\IActionProvider.cs" />
     <Compile Include="Components\Combat\IOperationSource.cs" />
@@ -89,6 +91,7 @@
     <Compile Include="Components\Targeting\StaticTarget.cs" />
     <Compile Include="Data\DataManagerFactory.cs" />
     <Compile Include="Components\Skills\ConfigurableSkillProvider.cs" />
+    <Compile Include="Data\Schema\AIAttackRuleSchema.cs" />
     <Compile Include="Text\TextUtils.cs" />
     <Compile Include="Coordinate.cs" />
     <Compile Include="Data\Encounter.cs" />


### PR DESCRIPTION
This resolves #52 and integrates in some of the attack skills for AI to choose from.

* cleaned up the json a little bit to reduce name and dataId, we'll most likely just use dataId for both unless their is a 'DisplayName'
* hooked up RLog printer to output
* added schema and everything in between to go from json -> ai rule behavior